### PR TITLE
Override single report

### DIFF
--- a/katuma.yml
+++ b/katuma.yml
@@ -23,4 +23,4 @@
         sockets_path: "{{ shared_path }}/sockets"
         log_path: "{{ shared_path }}/log"
         pids_path: "{{ shared_path }}/pids"
-        ofn_route_override: "/admin/reports/orders_and_fulfillment"
+        ofn_route_override: "/admin/reports/order_cycle_management"

--- a/roles/katuma_reports/handlers/main.yml
+++ b/roles/katuma_reports/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: reload nginx
+  service:
+    name: nginx
+    state: reloaded

--- a/roles/katuma_reports/tasks/main.yml
+++ b/roles/katuma_reports/tasks/main.yml
@@ -44,3 +44,5 @@
   with_items:
     - { src: "katuma_reports_upstream.conf.j2", dest: "/etc/nginx/conf.d/katuma_reports_upstream.conf" }
     - { src: "katuma_reports.conf.j2", dest: "/etc/nginx/sites-available/ofn/katuma_reports.conf" }
+  notify:
+    - reload nginx


### PR DESCRIPTION
When we overrode `/admin/reports/orders_and_fulfillment` URL we made impossible to see any of the four reports of that type. See screenshot below:

![reports](https://user-images.githubusercontent.com/762088/31432621-4986b41c-ae77-11e7-983b-fdbea15727f6.png)

This is because their URLs conform to `https://staging.katuma.org/admin/reports/orders_and_fulfillment?report_type=<report_type>`. As the query string is not matched by nginx, all four URLs pointed to Katuma reports.

What I suggest instead, is to override the report shown below that we know it's not used by any user yet and doesn't have much value for Katuma. 

![new_report](https://user-images.githubusercontent.com/762088/31432781-c0827286-ae77-11e7-9098-48c497688b99.png)
