### PR TITLE
Add backups role

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,2 +1,4 @@
 - src: carlosbuenosvinos.ansistrano-deploy
   version: 2.7.0
+- src: donat-b.restic
+  version: 0.4

--- a/katuma.yml
+++ b/katuma.yml
@@ -15,6 +15,7 @@
 
   roles:
     - role: node-exporter
+    - role: backups
     - role: katuma_reports
       vars:
         app_path: "/home/{{ unicorn_user }}/apps/katuma_reports"

--- a/roles/backups/files/backups.sh
+++ b/roles/backups/files/backups.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Backup git revision
+pushd /home/openfoodnetwork/apps/openfoodnetwork/current
+git rev-parse --verify HEAD > /tmp/git_rev
+popd
+
+# Postgres DB dump
+sudo su -c '/usr/bin/pg_dump --encoding=UTF8 "openfoodnetwork"' postgres > /tmp/pg_dump
+
+# Compress /shared directory
+tar -zcvf /tmp/shared.tar.gz /home/openfoodnetwork/apps/openfoodnetwork/shared

--- a/roles/backups/tasks/main.yml
+++ b/roles/backups/tasks/main.yml
@@ -1,0 +1,43 @@
+---
+- name: Ensure directory for user scripts exists
+  file:
+    path: /home/ofn-admin/bin
+    state: directory
+    owner: "{{ user }}"
+    group: "{{ user }}"
+    mode: 0775
+
+- name: Copy backup script
+  copy:
+    src: files/backups.sh
+    dest: /home/ofn-admin/bin/backups.sh
+    owner: "{{ user }}"
+    group: "{{ user }}"
+    mode: 0775
+
+- name: Install restic
+  vars:
+    restic_version: '0.8.1'
+    restic_repos:
+      - name: 'katuma'
+        url: 'b2:katuma-staging'
+        password: "{{ restic_password }}"
+        access_key: "{{ b2_account_id }}"
+        secret_key: "{{ b2_account_key }}"
+    restic_jobs_raw:
+      - command: '/home/ofn-admin/bin/backups.sh && restic backup /tmp/git_rev /tmp/pg_dump /tmp/shared.tar.gz'
+        at: '5 10 * * *'
+        user: "{{ user }}"
+      - command: 'restic forget --keep-last 5 --prune'
+        at: '5 11 */5 * *'
+        user: "{{ user }}"
+  include_role:
+    name: vendor/enricostano.ansible-restic
+
+# This override is needed until the following issue get solved:
+# https://github.com/donat-b/ansible-restic/pull/5#issuecomment-355022413
+- name: Ensure restic password file can be read by ofn-admin user
+  file:
+    path: '/var/lib/restic/passwd_katuma'
+    owner: "{{ user }}"
+    group: "{{ user }}"

--- a/roles/backups/tasks/main.yml
+++ b/roles/backups/tasks/main.yml
@@ -20,10 +20,10 @@
     restic_version: '0.8.1'
     restic_repos:
       - name: 'katuma'
-        url: 'b2:katuma-staging'
+        url: "{{ backup_bucket_url }}"
         password: "{{ restic_password }}"
-        access_key: "{{ b2_account_id }}"
-        secret_key: "{{ b2_account_key }}"
+        access_key: "{{ backup_account_id }}"
+        secret_key: "{{ backup_account_key }}"
     restic_jobs_raw:
       - command: '/home/ofn-admin/bin/backups.sh && restic backup /tmp/git_rev /tmp/pg_dump /tmp/shared.tar.gz'
         at: '5 10 * * *'


### PR DESCRIPTION
We need to backup 3 things:

 - git revision of code in `/current` directory
 - DB dump
 - content of `/shared` directory

In this way we'll be able to restore the application state at a given time.

TODO:

 - [ ] add doc
 - [x] where is the `ansible-restic` role