### PR TITLE
Remove left overs from Prometheus

### DIFF
--- a/katuma.yml
+++ b/katuma.yml
@@ -4,15 +4,6 @@
   remote_user: "{{ user }}"
   become: true
 
-  vars:
-    prometheus_group: prometheus
-    prometheus_user: prometheus
-    prometheus_install_path: /opt/prometheus
-    prometheus_log_path: /var/log/prometheus
-    prometheus_pid_path: /var/run/prometheus
-    prometheus_db_path: /var/lib/prometheus
-    node_exporter_version: 0.14.0
-
   roles:
     - role: katuma_reports
       vars:


### PR DESCRIPTION
Prometheus' node exporter was removed in https://github.com/coopdevs/katuma-provisioning/pull/11 but its vars were left untouched. 

We can enable both changes back once we have Prometheus set up.