### PR TITLE
Redirect permanently Katuma's alpha to app

### DIFF
--- a/katuma.yml
+++ b/katuma.yml
@@ -14,3 +14,16 @@
         log_path: "{{ shared_path }}/log"
         pids_path: "{{ shared_path }}/pids"
         ofn_route_override: "/admin/reports/order_cycle_management"
+
+    - role: jdauphant.nginx
+      vars:
+        - old_domain: alpha.katuma.org
+      nginx_sites:
+        katuma_redirect:
+          - listen 443 ssl http2
+          - listen [::]:443 ssl http2
+          - server_name {{ old_domain }}
+          - return 301 https://{{ domain }}$request_uri
+
+          - ssl_certificate      /etc/letsencrypt/live/{{ certbot_cert_name | default(domain) }}/fullchain.pem
+          - ssl_certificate_key  /etc/letsencrypt/live/{{ certbot_cert_name | default(domain) }}/privkey.pem


### PR DESCRIPTION
## Description

Closes #13 

Now that we got app.katuma.org up and running we need to tell browsers and any other HTTP clients that alpha.katuma.org is deprecated, while not breaking any old link. As long as more browsers cache this, we should see less traffic hitting the alpha subdomain.

This decouples this temporal solution from ofn-install and makes it easier to eventually remove it.

## Dependencies

This needs https://github.com/openfoodfoundation/ofn-install/pull/319/ to work.