### PR TITLE
Remove Katuma's custom report from production

### DIFF
--- a/roles/katuma_reports/tasks/main.yml
+++ b/roles/katuma_reports/tasks/main.yml
@@ -1,8 +1,14 @@
 ---
-- name: Create katuma_reports directories
+- name: Disable and stop systemd service unit
+  systemd:
+    name: "katuma_reports_unicorn.service"
+    enabled: false
+    state: stopped
+
+- name: Remove katuma_reports directories
   file:
     path: "{{ item }}"
-    state: directory
+    state: absent
     owner: "{{ unicorn_user }}"
   with_items:
     - "{{ app_path }}"
@@ -12,37 +18,24 @@
     - "{{ log_path }}"
     - "{{ pids_path }}"
 
-- name: Create configuration files from templates
-  template:
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
-    owner: "{{ unicorn_user }}"
-    mode: "0775"
-  with_items:
-    - { src: "application.yml.j2", dest: "{{ config_path }}/application.yml" }
+- name: Remove systemd service unit
+  file:
+    path: "/etc/systemd/system/katuma_reports_unicorn.service"
+    state: absent
 
-- name: Create systemd service unit
-  template:
-    src: "katuma_reports_unicorn.service.j2"
-    dest: "/etc/systemd/system/katuma_reports_unicorn.service"
-
-- name: Enable and start systemd service unit
-  systemd:
-    name: "katuma_reports_unicorn.service"
-    enabled: true
-    state: started
-
-- name: Create custom nginx configuration directory
+- name: Remove custom nginx configuration directory
   file:
     path: "/etc/nginx/sites-available/ofn"
-    state: directory
+    state: absent
+  notify:
+    - reload nginx
 
-- name: Create nginx server configuration
-  template:
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
+- name: Remove nginx server configuration
+  file:
+    path: "{{ item }}"
+    state: absent
   with_items:
-    - { src: "katuma_reports_upstream.conf.j2", dest: "/etc/nginx/conf.d/katuma_reports_upstream.conf" }
-    - { src: "katuma_reports.conf.j2", dest: "/etc/nginx/sites-available/ofn/katuma_reports.conf" }
+    - "/etc/nginx/conf.d/katuma_reports_upstream.conf"
+    - "/etc/nginx/sites-available/ofn/katuma_reports.conf"
   notify:
     - reload nginx

--- a/roles/katuma_reports/tasks/main.yml
+++ b/roles/katuma_reports/tasks/main.yml
@@ -1,10 +1,4 @@
 ---
-- name: Disable and stop systemd service unit
-  systemd:
-    name: "katuma_reports_unicorn.service"
-    enabled: false
-    state: stopped
-
 - name: Remove katuma_reports directories
   file:
     path: "{{ item }}"


### PR DESCRIPTION
There's been a single request for this hacky report in the last month and from the only hub that actively used it (Ridorta). It was someone from home that did not know how to access the one Ridorta started using last year.

IMO it's a must we stop serving this custom report now that user acquisition is growing. If more hubs adopt it, it'll be harder to remove in the future and we might even need to maintain it and we can't afford it. On the other hand, the server needs the RAM this app server takes and hopefully, we can then remove swap.

It's been fully confirmed OFN's built-in packing report provides the same information as our custom one.

**I've manually stopped the server in production already** so no one else uses it.